### PR TITLE
V1 chat links

### DIFF
--- a/src/LibChatMessage.lua
+++ b/src/LibChatMessage.lua
@@ -609,7 +609,7 @@ EVENT_MANAGER:RegisterForEvent(LIB_IDENTIFIER, EVENT_ADD_ON_LOADED, function(eve
         end
         if button == MOUSE_BUTTON_INDEX_LEFT then
             local unknownType = ...
-            ZO_Alert(EVENT_UI_ERROR, SOUNDS.INVENTORY_ITEM_LOCKED, zo_strformat(LIB_CHATMESSAGE_UNKNOWN_DESCRIPTION, unknownType))
+            ZO_Alert(EVENT_UI_ERROR, SOUNDS.NEGATIVE_CLICK, zo_strformat(LIB_CHATMESSAGE_UNKNOWN_DESCRIPTION, unknownType))
             return true
         end
     end

--- a/src/LibChatMessage.lua
+++ b/src/LibChatMessage.lua
@@ -130,10 +130,11 @@ end
 
 ----------------------------------------------
 
-UNKNOWN_LINK_TYPE = "unknown"
+local UNKNOWN_LINK_TYPE = "unknown"
+lib.UNKNOWN_LINK_TYPE = UNKNOWN_LINK_TYPE
 local LINK_GMATCH_PATTERN = "||H(%d):(.-):(.-)||h(.-)||h"
 local function unknownTypeReformatter(linkStyle, linkType, data, displayText)
-    return string.format("|H%i:%s:%s|h%s|h", linkStyle, UNKNOWN_LINK_TYPE, linkType, displayText)
+    return ZO_LinkHandler_CreateLinkWithoutBrackets(displayText, nil, UNKNOWN_LINK_TYPE, linkType)
 end
 local function decodeCustomLinks(linkStyle, linkType, data, displayText)
     local reformatter = lib.registeredChatLinks[linkType] or unknownTypeReformatter
@@ -147,11 +148,11 @@ local function customLinkFormatter(messageType, fromName, text, ...)
 end
 
 local function defaultReformatter(linkStyle, linkType, data, displayText)
-    return string.format("|H%i:%s:%s|h[%s]|h", linkStyle, linkType, data, displayText)
+    return ZO_LinkHandler_CreateLinkWithFormat(displayText, nil, linkType, linkStyle, data)
 end
 
 function lib:RegisterCustomChatLink(linkType, optionalReformatter)
-    assert(not optionalReformatter or type(optionalReformatter) == "function", "Reformatter needs to be a function")
+    assert(not optionalReformatter or type(optionalReformatter) == "function", "Reformatter has to be a function")
     self.registeredChatLinks[linkType] = optionalReformatter or defaultReformatter
 	ZO_VALID_LINK_TYPES_CHAT[linkType] = true
 end
@@ -609,10 +610,7 @@ EVENT_MANAGER:RegisterForEvent(LIB_IDENTIFIER, EVENT_ADD_ON_LOADED, function(eve
         end
         if button == MOUSE_BUTTON_INDEX_LEFT then
             local unknownType = ...
-			PlaySound(SOUNDS.DEFAULT_CLICK)
-            ClearTooltip(PopupTooltip)
-            InitializeTooltip(PopupTooltip)
-            PopupTooltip:AddLine(zo_strformat(LIB_CHATMESSAGE_UNKNOWN_DESCRIPTION, unknownType))
+            ZO_Alert(EVENT_UI_ERROR, SOUNDS.INVENTORY_ITEM_LOCKED, zo_strformat(LIB_CHATMESSAGE_UNKNOWN_DESCRIPTION, unknownType))
             return true
         end
     end

--- a/src/LibChatMessage.lua
+++ b/src/LibChatMessage.lua
@@ -50,6 +50,8 @@ lib.defaultSettings = {
 lib.chatHistory = {}
 lib.chatHistoryActive = true
 
+lib.registeredChatLinks = {}
+
 -- internal functions
 
 local function GetFormattedTime(timeStamp)
@@ -90,17 +92,71 @@ end
 
 -- chat system hooks
 local messageFormatters = CHAT_ROUTER:GetRegisteredMessageFormatters()
-local function PostHookFormatter(eventType, postHook)
-    local originalFormatter = messageFormatters[eventType]
-    messageFormatters[eventType] = function(...)
+local newFormatter = {}
+do
+    local redirect = {}
+    setmetatable(redirect, newFormatter)
+    redirect.__index = function(_, key)
+        -- Called, if newFormatter has no entry: use original.
+        return messageFormatters[key]
+    end
+    SecurePostHook(CHAT_ROUTER, "FormatAndAddChatMessage", function(self)
+        -- Restore Formatters for addons
+        self.registeredMessageFormatters = messageFormatters
+    end)
+    local orgOnChatEvent = CHAT_ROUTER.FormatAndAddChatMessage
+    function CHAT_ROUTER.FormatAndAddChatMessage(self, ...)
+        if IsChatSystemAvailableForCurrentPlatform() then
+            -- Replace Formatters for ZOS
+            self.registeredMessageFormatters = newFormatter
+        end
+        return orgOnChatEvent(self, ...)
+    end
+end
+
+local function dummyPreHook(...) return ... end
+local function PostHookFormatter(eventType, postHook, preHook)
+    preHook = preHook or dummyPreHook
+    newFormatter[eventType] = function(...)
         local timeStamp, isRestoring = GetTimeStampForEvent()
         if(not isRestoring) then
             StoreChatEvent(timeStamp, eventType, ...)
         end
-        local formattedEventText, targetChannel, fromDisplayName, rawMessageText = originalFormatter(...)
+        local originalFormatter = messageFormatters[eventType]
+        local formattedEventText, targetChannel, fromDisplayName, rawMessageText = originalFormatter(preHook(...))
         return postHook(formattedEventText, targetChannel, fromDisplayName, rawMessageText, timeStamp)
     end
 end
+
+----------------------------------------------
+
+UNKNOWN_LINK_TYPE = "unknown"
+local LINK_GMATCH_PATTERN = "||H(%d):(.-):(.-)||h(.-)||h"
+local function unknownTypeReformatter(linkStyle, linkType, data, displayText)
+    return string.format("|H%i:%s:%s|h%s|h", linkStyle, UNKNOWN_LINK_TYPE, linkType, displayText)
+end
+local function decodeCustomLinks(linkStyle, linkType, data, displayText)
+    local reformatter = lib.registeredChatLinks[linkType] or unknownTypeReformatter
+    linkStyle = tonumber(linkStyle)
+    return reformatter(linkStyle, linkType, data, displayText)
+end
+-- The chat event escapes unknown links. Here it gets unescaped.
+local function customLinkFormatter(messageType, fromName, text, ...)
+    text = text:gsub(LINK_GMATCH_PATTERN, decodeCustomLinks)
+    return messageType, fromName, text, ...
+end
+
+local function defaultReformatter(linkStyle, linkType, data, displayText)
+    return string.format("|H%i:%s:%s|h[%s]|h", linkStyle, linkType, data, displayText)
+end
+
+function lib:RegisterCustomChatLink(linkType, optionalReformatter)
+    assert(not optionalReformatter or type(optionalReformatter) == "function", "Reformatter needs to be a function")
+    self.registeredChatLinks[linkType] = optionalReformatter or defaultReformatter
+	ZO_VALID_LINK_TYPES_CHAT[linkType] = true
+end
+
+----------------------------------------------
 
 -- CHAT_ROUTER:FormatAndAddChatMessage(EVENT_CHAT_MESSAGE_CHANNEL, CHAT_CHANNEL_SAY, "test", "test", false, "test")
 PostHookFormatter(EVENT_CHAT_MESSAGE_CHANNEL, function(formattedEventText, targetChannel, fromDisplayName, rawMessageText, timeStamp)
@@ -108,7 +164,7 @@ PostHookFormatter(EVENT_CHAT_MESSAGE_CHANNEL, function(formattedEventText, targe
         formattedEventText = MESSAGE_TEMPLATE:format(GetFormattedTime(timeStamp), formattedEventText)
     end
     return formattedEventText, targetChannel, fromDisplayName, rawMessageText
-end)
+end, customLinkFormatter)
 
 -- CHAT_ROUTER:FormatAndAddChatMessage(EVENT_BROADCAST, "test")
 PostHookFormatter(EVENT_BROADCAST, function(formattedEventText, targetChannel, fromDisplayName, rawMessageText, timeStamp)
@@ -546,4 +602,21 @@ EVENT_MANAGER:RegisterForEvent(LIB_IDENTIFIER, EVENT_ADD_ON_LOADED, function(eve
     if(not lib.chatHistoryActive) then
         lib:ClearHistory()
     end
+
+    local function OnLinkClicked(link, button, text, color, linkType, ...)
+        if linkType ~= UNKNOWN_LINK_TYPE then
+            return
+        end
+        if button == MOUSE_BUTTON_INDEX_LEFT then
+            local unknownType = ...
+			PlaySound(SOUNDS.DEFAULT_CLICK)
+            ClearTooltip(PopupTooltip)
+            InitializeTooltip(PopupTooltip)
+            PopupTooltip:AddLine(zo_strformat(LIB_CHATMESSAGE_UNKNOWN_DESCRIPTION, unknownType))
+            return true
+        end
+    end
+	LINK_HANDLER:RegisterCallback(LINK_HANDLER.LINK_CLICKED_EVENT, OnLinkClicked)
+	LINK_HANDLER:RegisterCallback(LINK_HANDLER.LINK_MOUSE_UP_EVENT, OnLinkClicked)
+	KEYBOARD_CHAT_SYSTEM:GetEditControl():SetAllowMarkupType(ALLOW_MARKUP_TYPE_ALL)
 end)

--- a/src/LibChatMessage.lua
+++ b/src/LibChatMessage.lua
@@ -95,23 +95,22 @@ local messageFormatters = CHAT_ROUTER:GetRegisteredMessageFormatters()
 local newFormatter = {}
 do
     local redirect = {}
-    setmetatable(redirect, newFormatter)
+    setmetatable(newFormatter, redirect)
     redirect.__index = function(_, key)
         -- Called, if newFormatter has no entry: use original.
         return messageFormatters[key]
     end
-    SecurePostHook(CHAT_ROUTER, "FormatAndAddChatMessage", function(self)
-        -- Restore Formatters for addons
-        self.registeredMessageFormatters = messageFormatters
-    end)
     local orgOnChatEvent = CHAT_ROUTER.FormatAndAddChatMessage
-    function CHAT_ROUTER.FormatAndAddChatMessage(self, ...)
+    ZO_PreHook(CHAT_ROUTER, "FormatAndAddChatMessage", function(self)
         if IsChatSystemAvailableForCurrentPlatform() then
             -- Replace Formatters for ZOS
             self.registeredMessageFormatters = newFormatter
         end
-        return orgOnChatEvent(self, ...)
-    end
+    end)
+    SecurePostHook(CHAT_ROUTER, "FormatAndAddChatMessage", function(self)
+        -- Restore Formatters for addons
+        self.registeredMessageFormatters = messageFormatters
+    end)
 end
 
 local function dummyPreHook(...) return ... end

--- a/src/LibChatMessage.txt
+++ b/src/LibChatMessage.txt
@@ -6,8 +6,8 @@
 ## IsLibrary: true
 ## SavedVariables: LibChatMessageSettings LibChatMessageHistory
 ##
-## This Add-on is not created by, affiliated with or sponsored by ZeniMax Media Inc. or its affiliates. 
-## The Elder Scrolls® and related logos are registered trademarks or trademarks of ZeniMax Media Inc. in the United States and/or other countries. 
+## This Add-on is not created by, affiliated with or sponsored by ZeniMax Media Inc. or its affiliates.
+## The Elder Scrolls® and related logos are registered trademarks or trademarks of ZeniMax Media Inc. in the United States and/or other countries.
 ## All rights reserved
 ##
 ## You can read the full terms at https://account.elderscrollsonline.com/add-on-terms

--- a/src/LibChatMessage.txt
+++ b/src/LibChatMessage.txt
@@ -12,4 +12,7 @@
 ##
 ## You can read the full terms at https://account.elderscrollsonline.com/add-on-terms
 
+lang/strings.lua
+lang/$(language).lua
+
 LibChatMessage.lua

--- a/src/lang/de.lua
+++ b/src/lang/de.lua
@@ -1,5 +1,5 @@
 local strings = {
-    ["LIB_CHATMESSAGE_UNKNOWN_DESCRIPTION"] = 'Der Chat-Link "<<1>>" wird zurzeit nicht unterstützt.\n\nStell sicher, dass das Addon installiert und aktiviert ist.\nEventuell den Absender fragen, welches Addon verwendet wird.'
+    ["LIB_CHATMESSAGE_UNKNOWN_DESCRIPTION"] = 'Der Chat-Link "<<1>>" wird zurzeit nicht unterstützt.'
 }
 for id, text in pairs(strings) do
     SafeAddString(_G[id], text)

--- a/src/lang/de.lua
+++ b/src/lang/de.lua
@@ -1,0 +1,6 @@
+local strings = {
+    ["LIB_CHATMESSAGE_UNKNOWN_DESCRIPTION"] = 'Der Chat-Link "<<1>>" wird zurzeit nicht unterstützt.\n\nStell sicher, dass das Addon installiert und aktiviert ist.\nEventuell den Absender fragen, welches Addon verwendet wird.'
+}
+for id, text in pairs(strings) do
+    SafeAddString(_G[id], text)
+end

--- a/src/lang/strings.lua
+++ b/src/lang/strings.lua
@@ -1,0 +1,6 @@
+local strings = {
+    ["LIB_CHATMESSAGE_UNKNOWN_DESCRIPTION"] = 'The chat link "<<1>>" is currently not supported.\n\nMake sure the addon is installed and activated.\nMay ask the sender which addon is used.'
+}
+for id, text in pairs(strings) do
+    ZO_CreateStringId(id, text)
+end

--- a/src/lang/strings.lua
+++ b/src/lang/strings.lua
@@ -1,5 +1,5 @@
 local strings = {
-    ["LIB_CHATMESSAGE_UNKNOWN_DESCRIPTION"] = 'The chat link "<<1>>" is currently not supported.\n\nMake sure the addon is installed and activated.\nMay ask the sender which addon is used.'
+    ["LIB_CHATMESSAGE_UNKNOWN_DESCRIPTION"] = 'The chat link "<<1>>" is currently not supported.'
 }
 for id, text in pairs(strings) do
     ZO_CreateStringId(id, text)


### PR DESCRIPTION
Prehook formatter, compatible with all chat addons.
Restore registered chat links.
Create generic unknown link for chat links not registered.

Should UNKOWN_LINK_TYPE be global?
Should PopupTooltip or ESO_Dialogs be used?
Your opinion?